### PR TITLE
Update version compatibility in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,16 @@ setuptools.setup(
     packages=setuptools.find_packages(),
     license='Apache 2.0',
     install_requires=[
-        'Jinja2==2.11.3',
-        'google-cloud-secret-manager==2.2.0',
+        'Jinja2 < 4',
+        'google-cloud-secret-manager < 3',
         # These are dependencies of secret-manager package, had to put
         # them here to make it work
-        'google-api-core[grpc]==1.25.1',
-        'grpc-google-iam-v1==0.12.3',
-        'proto-plus==1.13.0',
+        'google-api-core[grpc] < 2',
+        'grpc-google-iam-v1 < 1',
+        'proto-plus < 2',
         'libcst >= 0.2.5',
-        'protobuf==3.14.0',
-        'googleapis-common-protos==1.52.0',
+        'protobuf < 4',
+        'googleapis-common-protos < 2',
     ],
     classifiers=[
         "Programming Language :: Python :: 3",


### PR DESCRIPTION
This caps the current versions so they can't go past the original major version (except Jinja2). I tested locally with all the latest versions this uses and there were no errors and the templates worked the same as with the older module versions.